### PR TITLE
fix: ensure compatibility of snapshot file creation with Windows OS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@
 node_modules
 prisma-clients
 snapshots
+migrations
 .DS_Store

--- a/src/dump.ts
+++ b/src/dump.ts
@@ -1,9 +1,10 @@
+import { MultiBar, Presets } from "cli-progress";
+import { createWriteStream, existsSync, readFileSync } from "fs";
+import { mkdir, readdir } from "fs/promises";
+import { join } from "path";
 import { PrismaClient } from "./prisma-clients/source";
 import { incrementalFieldInModel } from "./prisma-clients/source/utils";
-import { createWriteStream, existsSync, readFileSync } from "fs";
-import { Presets, MultiBar } from "cli-progress";
-import { join } from "path";
-import { mkdir, readdir } from "fs/promises";
+import { fileName } from "./utils/fileName";
 import { progressBarFormat } from "./utils/parseProgressBarFormat";
 
 type ModelName = keyof typeof incrementalFieldInModel;
@@ -69,10 +70,16 @@ const extractRecords = async (modelName: ModelName, progressBar) => {
     console.log("\n------------------ Extracting ------------------\n");
   }
   const currentSnapshotPath = join(snapshotsPath, modelName);
+
   if (!existsSync(currentSnapshotPath)) await mkdir(currentSnapshotPath);
-  const stream = createWriteStream(
-    join(currentSnapshotPath, `${now.toISOString()}.json`)
+
+  const currentStreamPath = join(
+    currentSnapshotPath,
+    fileName.transformToValidFilename(now.toISOString())
   );
+
+  const stream = createWriteStream(currentStreamPath);
+
   stream.write("[");
   let skip = 0;
   let batch = [];

--- a/src/utils/fileName.ts
+++ b/src/utils/fileName.ts
@@ -1,0 +1,12 @@
+const transformToValidFilename = (ISOString: string) => {
+  return ISOString.replace(/:/g, "_") + ".json";
+};
+
+const transformToValidISOString = (name: string) => {
+  return name.replace(/_/g, ":");
+};
+
+export const fileName = {
+  transformToValidFilename,
+  transformToValidISOString,
+};


### PR DESCRIPTION
Because Windows does not accept file names containing ':', I implemented a utility to convert ISO date names to a compatible format, and revert them when needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated `.gitignore` to exclude the `migrations` directory.
  
- **New Features**
  - Introduced string transformation functions for filenames and ISO strings to ensure valid naming conventions. 

- **Improvements**
  - Optimized import organization for better code readability and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->